### PR TITLE
feat(startup): pitch detail + AI panel redesign

### DIFF
--- a/apps/web/src/components/shared/glow-border.tsx
+++ b/apps/web/src/components/shared/glow-border.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { cn } from "@workspace/ui/lib/utils";
+import type { CSSProperties, ReactNode } from "react";
+
+interface GlowBorderProps {
+  children: ReactNode;
+  className?: string;
+  /** Border radius in px. Default 16. */
+  radius?: number;
+  /** Glow border width in px. Default 1.5. */
+  borderWidth?: number;
+  /** Animation cycle duration in seconds. Default 4. */
+  speed?: number;
+  /** Whether the glow is active. Default true. */
+  active?: boolean;
+}
+
+/**
+ * Animated hue-cycling border that wraps any content.
+ * Uses @property (registered in globals.css) for smooth hue interpolation.
+ */
+export function GlowBorder({
+  children,
+  className,
+  radius = 16,
+  borderWidth = 1.5,
+  speed = 4,
+  active = true,
+}: GlowBorderProps) {
+  const innerRadius = radius - borderWidth;
+
+  const wrapStyle: CSSProperties = {
+    position: "relative",
+    borderRadius: radius,
+    padding: borderWidth,
+  };
+
+  const borderStyle: CSSProperties = {
+    position: "absolute",
+    inset: 0,
+    borderRadius: radius,
+    zIndex: 0,
+    background: `
+      radial-gradient(
+        35% 35% at calc(var(--glow-bg-x) * 1%) calc(var(--glow-bg-y) * 1%),
+        hsl(calc(var(--glow-hue) * 1deg) 85% 65%) 0%,
+        hsl(calc(var(--glow-hue) * 1deg) 70% 45%) 40%,
+        var(--border) 100%
+      )
+    `,
+    animation: `glow-hue-cycle ${speed}s linear infinite, glow-border-orbit ${speed}s linear infinite`,
+    opacity: active ? 1 : 0.6,
+    transition: "opacity 0.5s ease",
+  };
+
+  const innerStyle: CSSProperties = {
+    position: "relative",
+    borderRadius: innerRadius,
+    zIndex: 1,
+    overflow: "hidden",
+  };
+
+  return (
+    <div className={cn(className)} style={wrapStyle}>
+      <div style={borderStyle} aria-hidden="true" />
+      <div className="bg-background" style={innerStyle}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/startup/ai-analysis-panel.tsx
+++ b/apps/web/src/components/startup/ai-analysis-panel.tsx
@@ -4,6 +4,8 @@ import { ChevronDown, Sparkles } from "lucide-react";
 import { AnimatePresence, animate, motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 
+import { GlowBorder } from "../shared/glow-border";
+
 interface AiAnalysis {
   overallScore: number;
   clarity: { score: number; feedback: string };
@@ -19,8 +21,7 @@ type Props = {
 
 /**
  * Visual weight by score — pink accent stroke for strong scores,
- * neutrals that recede for weaker ones. Communicates quality
- * through intensity, not hue.
+ * neutrals that recede for weaker ones.
  */
 function scoreWeight(score: number) {
   if (score >= 70) {
@@ -43,7 +44,7 @@ function scoreWeight(score: number) {
 
 // ── Animation primitives ──
 
-/** Tracks element dimensions via ResizeObserver using a callback ref. */
+/** Tracks element dimensions via ResizeObserver. */
 function useMeasure() {
   const [node, setNode] = useState<HTMLDivElement | null>(null);
   const [bounds, setBounds] = useState({ height: 0 });
@@ -61,7 +62,7 @@ function useMeasure() {
   return [setNode, bounds] as const;
 }
 
-/** Blur-in letter-by-letter text reveal. Fires onComplete after last letter. */
+/** Blur-in letter-by-letter text reveal. */
 function BlurRevealText({
   text,
   delay = 0,
@@ -105,10 +106,7 @@ function BlurRevealText({
           initial={{ filter: "blur(4px)", opacity: 0, y: 5 }}
           animate={{ filter: "blur(0px)", opacity: 1, y: 0 }}
           style={{ willChange: "transform, filter" }}
-          transition={{
-            duration: 0.15,
-            delay: delayPerChar * i,
-          }}
+          transition={{ duration: 0.15, delay: delayPerChar * i }}
           onAnimationComplete={
             i === letters.length - 1
               ? () => {
@@ -127,7 +125,7 @@ function BlurRevealText({
   );
 }
 
-/** Animates a number counting up from 0 to target. Calls onComplete when done. */
+/** Animates a number counting up from 0 to target. */
 function CountUp({
   target,
   delay = 0,
@@ -230,16 +228,14 @@ function ScoreGauge({
 
 // ── Composite components ──
 
-/** Thin gradient divider between content sections. */
 function SectionDivider() {
   return (
-    <div className="h-px bg-gradient-to-r from-transparent via-neutral-200/60 to-transparent dark:via-white/5" />
+    <div className="mx-1 h-px bg-gradient-to-r from-transparent via-neutral-200/50 to-transparent dark:via-white/[0.04]" />
   );
 }
 
 /**
- * Dimension metric row — ring gauge on the left with score centered inside,
- * label and blur-in feedback on the right. Editorial two-column layout.
+ * Dimension metric row — ring gauge left, label + feedback right.
  */
 function DimensionRow({
   label,
@@ -262,28 +258,25 @@ function DimensionRow({
 
   return (
     <motion.div
-      className="flex gap-4"
-      initial={{ opacity: 0, y: 10 }}
+      className="flex gap-4 px-5 py-4"
+      initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, ease: "easeOut" }}
+      transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
     >
-      {/* Ring gauge with score centered inside */}
       <div className="shrink-0 pt-0.5">
-        <ScoreGauge score={score} size={48} strokeWidth={2.5}>
+        <ScoreGauge score={score} size={44} strokeWidth={2.5}>
           <CountUp
             target={score}
             delay={150}
-            className={`text-sm font-bold tabular-nums ${weight.text}`}
+            className={`text-[13px] font-bold tabular-nums ${weight.text}`}
           />
         </ScoreGauge>
       </div>
-
-      {/* Label + blur-reveal feedback */}
-      <div className="min-w-0 flex-1 pt-1">
-        <span className="text-sm font-semibold text-neutral-700 dark:text-white/70">
+      <div className="min-w-0 flex-1 pt-0.5">
+        <span className="text-[13px] font-semibold text-neutral-800 dark:text-white/80">
           {label}
         </span>
-        <p className="mt-1.5 text-sm leading-relaxed text-neutral-500 dark:text-white/45">
+        <p className="mt-1 text-[13px] leading-relaxed text-neutral-500 dark:text-white/40">
           {revealReady ? (
             <BlurRevealText
               text={feedback}
@@ -297,7 +290,7 @@ function DimensionRow({
   );
 }
 
-/** Centered overall score — large ring gauge hero with radial glow. */
+/** Overall score — hero ring gauge with subtle radial glow. */
 function OverallScoreSection({
   score,
   onComplete,
@@ -307,28 +300,27 @@ function OverallScoreSection({
 }) {
   return (
     <motion.div
-      className="relative flex flex-col items-center py-3"
-      initial={{ opacity: 0, scale: 0.92 }}
+      className="relative flex flex-col items-center px-5 py-5"
+      initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.6, ease: "easeOut" }}
+      transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
     >
-      {/* Radial glow */}
       <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-        <div className="size-32 rounded-full bg-pink-500/5 blur-2xl dark:bg-pink-500/10" />
+        <div className="size-28 rounded-full bg-pink-500/[0.04] blur-2xl dark:bg-pink-500/[0.08]" />
       </div>
 
-      <span className="relative mb-3 flex items-center gap-1.5 text-xs font-medium uppercase tracking-widest text-pink-500/70 dark:text-pink-400/50">
+      <span className="relative mb-3 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-widest text-pink-500/60 dark:text-pink-400/40">
         <Sparkles className="size-3" />
         Overall Score
       </span>
 
       <div className="relative">
-        <ScoreGauge score={score} size={80} strokeWidth={4} delay={0.3}>
+        <ScoreGauge score={score} size={72} strokeWidth={3.5} delay={0.3}>
           <CountUp
             target={score}
             delay={400}
             onComplete={onComplete}
-            className="text-2xl font-bold tabular-nums text-neutral-900 dark:text-white"
+            className="text-xl font-bold tabular-nums text-neutral-900 dark:text-white"
           />
         </ScoreGauge>
       </div>
@@ -336,7 +328,7 @@ function OverallScoreSection({
   );
 }
 
-/** Single suggestion row with numbered badge and blur-in text. */
+/** Single suggestion row with numbered badge. */
 function SuggestionRow({
   index,
   text,
@@ -348,15 +340,15 @@ function SuggestionRow({
 }) {
   return (
     <motion.li
-      className="flex gap-3 text-sm"
-      initial={{ opacity: 0, x: -6 }}
+      className="flex gap-3 text-[13px]"
+      initial={{ opacity: 0, x: -4 }}
       animate={{ opacity: 1, x: 0 }}
-      transition={{ duration: 0.3 }}
+      transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
     >
-      <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-pink-500/10 text-xs font-bold text-pink-500 dark:bg-pink-500/15">
+      <span className="mt-[3px] flex size-[18px] shrink-0 items-center justify-center rounded-full bg-pink-500/10 text-[10px] font-bold text-pink-500 dark:bg-pink-500/15">
         {index + 1}
       </span>
-      <span className="text-neutral-500 dark:text-white/45">
+      <span className="text-neutral-500 dark:text-white/40">
         <BlurRevealText
           text={text}
           delay={100}
@@ -370,11 +362,6 @@ function SuggestionRow({
 
 // ── Content orchestrator ──
 
-/**
- * Sequential animation flow via step state machine.
- * Steps: 1-3 = dimension rows, 4 = overall score,
- *         5+ = suggestions, last = footer.
- */
 function AnalysisContent({ analysis }: { analysis: AiAnalysis }) {
   const [step, setStep] = useState(0);
 
@@ -389,7 +376,7 @@ function AnalysisContent({ analysis }: { analysis: AiAnalysis }) {
 
   const formattedDate = new Date(analysis.analyzedAt).toLocaleDateString(
     "en-US",
-    { year: "numeric", month: "short", day: "numeric" }
+    { year: "numeric", month: "short", day: "numeric" },
   );
 
   useEffect(() => {
@@ -398,40 +385,30 @@ function AnalysisContent({ analysis }: { analysis: AiAnalysis }) {
   }, []);
 
   return (
-    <div className="relative px-6 py-6">
-      {/* Atmospheric background gradient */}
-      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-pink-50/30 via-transparent to-violet-50/20 dark:from-pink-500/5 dark:via-transparent dark:to-violet-500/5" />
+    <div className="relative py-1">
+      {/* Atmospheric background */}
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-pink-50/20 via-transparent to-violet-50/10 dark:from-pink-500/[0.03] dark:via-transparent dark:to-violet-500/[0.03]" />
 
       <div className="relative">
-        {/* Dimension rows with dividers between them */}
-        <div>
-          {dimensions.map((dim, i) => (
-            <div key={dim.label}>
-              {step >= i + 1 ? (
-                <div className={i > 0 ? "pt-5" : ""}>
-                  <DimensionRow
-                    label={dim.label}
-                    score={dim.score}
-                    feedback={dim.feedback}
-                    onComplete={() => setStep(i + 2)}
-                  />
-                </div>
-              ) : null}
-              {step >= i + 2 && i < dimensions.length - 1 && (
-                <div className="mt-5">
-                  <SectionDivider />
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
+        {/* Dimension rows */}
+        {dimensions.map((dim, i) => (
+          <div key={dim.label}>
+            {step >= i + 1 ? (
+              <DimensionRow
+                label={dim.label}
+                score={dim.score}
+                feedback={dim.feedback}
+                onComplete={() => setStep(i + 2)}
+              />
+            ) : null}
+            {step >= i + 2 && i < dimensions.length - 1 && <SectionDivider />}
+          </div>
+        ))}
 
-        {/* Overall score — hero moment after all dimension rows */}
+        {/* Overall score */}
         {step >= 4 && (
           <>
-            <div className="my-5">
-              <SectionDivider />
-            </div>
+            <SectionDivider />
             <OverallScoreSection
               score={analysis.overallScore}
               onComplete={() => setStep(5)}
@@ -439,15 +416,13 @@ function AnalysisContent({ analysis }: { analysis: AiAnalysis }) {
           </>
         )}
 
-        {/* Suggestions — one at a time */}
+        {/* Suggestions */}
         {step >= suggestionsStart && (
           <>
-            <div className="my-5">
-              <SectionDivider />
-            </div>
-            <div>
+            <SectionDivider />
+            <div className="px-5 py-4">
               <motion.p
-                className="mb-3 text-xs font-medium uppercase tracking-widest text-neutral-400 dark:text-white/30"
+                className="mb-3 text-[11px] font-medium uppercase tracking-widest text-neutral-400 dark:text-white/25"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 transition={{ duration: 0.3 }}
@@ -463,7 +438,7 @@ function AnalysisContent({ analysis }: { analysis: AiAnalysis }) {
                       text={suggestion}
                       onComplete={() => setStep(suggestionsStart + i + 1)}
                     />
-                  ) : null
+                  ) : null,
                 )}
               </ol>
             </div>
@@ -473,7 +448,7 @@ function AnalysisContent({ analysis }: { analysis: AiAnalysis }) {
         {/* Footer */}
         {step >= footerStep && (
           <motion.p
-            className="mt-6 text-center text-xs text-neutral-300 dark:text-white/15"
+            className="border-t border-neutral-100/50 px-5 py-3 text-center text-[11px] text-neutral-300 dark:border-white/[0.03] dark:text-white/15"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.5 }}
@@ -488,107 +463,68 @@ function AnalysisContent({ analysis }: { analysis: AiAnalysis }) {
 
 // ── Main panel ──
 
-/**
- * AI analysis panel with sequential blur-in reveal.
- * Shimmer-accented trigger, ring gauges with scores inside,
- * atmospheric gradient interior, large hero ring for overall.
- */
 export function AiAnalysisPanel({ analysis }: Props) {
   const [isOpen, setIsOpen] = useState(false);
   const [measureRef, bounds] = useMeasure();
 
   return (
-    <div
-      className={`group/panel overflow-hidden rounded-2xl border transition-all duration-500 ${
-        isOpen
-          ? "border-pink-200/50 shadow-lg shadow-pink-500/5 dark:border-pink-500/15 dark:shadow-pink-500/5"
-          : "border-neutral-200/80 hover:border-pink-300/40 dark:border-white/10 dark:hover:border-pink-500/20"
-      }`}
-    >
-      {/* Trigger */}
-      <button
-        type="button"
-        aria-expanded={isOpen}
-        aria-controls="ai-analysis-content"
-        onClick={() => setIsOpen(!isOpen)}
-        className={`relative flex w-full items-center justify-between overflow-hidden px-5 py-4 transition-all ${
-          isOpen
-            ? "bg-transparent"
-            : "bg-gradient-to-r from-pink-50/50 via-white to-violet-50/40 hover:from-pink-50/70 hover:to-violet-50/60 dark:from-pink-500/5 dark:via-transparent dark:to-violet-500/5 dark:hover:from-pink-500/10 dark:hover:to-violet-500/10"
-        }`}
-      >
-        {/* Animated shimmer line across top edge when closed */}
-        {!isOpen && (
-          <div className="absolute inset-x-0 top-0 h-px overflow-hidden">
-            <motion.div
-              className="h-full w-1/3 bg-gradient-to-r from-transparent via-pink-400/40 to-transparent"
-              animate={{ x: ["-100%", "400%"] }}
-              transition={{
-                duration: 3,
-                repeat: Infinity,
-                ease: "linear",
-              }}
-            />
-          </div>
-        )}
-
-        <div className="flex items-center gap-3">
-          <motion.div
-            className="flex size-7 items-center justify-center rounded-lg bg-gradient-to-br from-pink-500/10 to-violet-500/10 dark:from-pink-500/15 dark:to-violet-500/15"
-            animate={isOpen ? { rotate: 0 } : { rotate: [0, 12, -12, 0] }}
-            transition={
-              isOpen
-                ? { duration: 0.2 }
-                : {
-                    duration: 2,
-                    repeat: Infinity,
-                    repeatDelay: 4,
-                    ease: "easeInOut",
-                  }
-            }
-          >
-            <Sparkles className="size-3.5 text-pink-500" />
-          </motion.div>
-          <span className="text-sm font-semibold text-neutral-900 dark:text-white">
-            AI Pitch Analysis
-          </span>
-        </div>
-
-        <div className="flex items-center gap-3">
-          {/* Mini score ring in trigger */}
-          <ScoreGauge score={analysis.overallScore} size={32} strokeWidth={2}>
-            <span className="text-xs font-bold tabular-nums text-neutral-700 dark:text-white/70">
-              {analysis.overallScore}
-            </span>
-          </ScoreGauge>
-          <ChevronDown
-            className={`size-4 text-neutral-400 transition-transform duration-300 ${
-              isOpen ? "rotate-180" : ""
-            }`}
-          />
-        </div>
-      </button>
-
-      {/* Expanding content with height animation */}
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            id="ai-analysis-content"
-            className="overflow-hidden border-t border-neutral-100/80 dark:border-white/5"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: bounds.height, opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{
-              height: { duration: 0.35, ease: "easeOut" },
-              opacity: { duration: 0.2, ease: "easeOut" },
-            }}
-          >
-            <div ref={measureRef}>
-              <AnalysisContent analysis={analysis} />
+    <GlowBorder radius={16} borderWidth={1.5} speed={4} active={!isOpen}>
+      <div className="overflow-hidden rounded-[14.5px]">
+        {/* Trigger */}
+        <button
+          type="button"
+          aria-expanded={isOpen}
+          aria-controls="ai-analysis-content"
+          onClick={() => setIsOpen(!isOpen)}
+          className="relative flex w-full items-center justify-between px-4 py-3.5 transition-colors hover:bg-neutral-50/50 dark:hover:bg-white/[0.02]"
+        >
+          <div className="flex items-center gap-3">
+            <div className="flex size-8 items-center justify-center rounded-[10px] bg-gradient-to-br from-pink-500/10 to-violet-500/10 dark:from-pink-500/15 dark:to-violet-500/15">
+              <Sparkles className="size-3.5 text-pink-500" />
             </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
+            <div className="text-left">
+              <span className="text-sm font-semibold text-neutral-900 dark:text-white">
+                AI Pitch Analysis
+              </span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2.5">
+            <ScoreGauge score={analysis.overallScore} size={30} strokeWidth={2}>
+              <span className="text-[10px] font-bold tabular-nums text-neutral-700 dark:text-white/70">
+                {analysis.overallScore}
+              </span>
+            </ScoreGauge>
+            <motion.div
+              animate={{ rotate: isOpen ? 180 : 0 }}
+              transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+            >
+              <ChevronDown className="size-4 text-neutral-400 dark:text-white/30" />
+            </motion.div>
+          </div>
+        </button>
+
+        {/* Expanding content */}
+        <AnimatePresence>
+          {isOpen && (
+            <motion.div
+              id="ai-analysis-content"
+              className="overflow-hidden border-t border-neutral-100/60 dark:border-white/[0.04]"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: bounds.height, opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{
+                height: { duration: 0.35, ease: [0.22, 1, 0.36, 1] },
+                opacity: { duration: 0.2 },
+              }}
+            >
+              <div ref={measureRef}>
+                <AnalysisContent analysis={analysis} />
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </GlowBorder>
   );
 }

--- a/apps/web/src/components/startup/markdown-toc.tsx
+++ b/apps/web/src/components/startup/markdown-toc.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { cn } from "@workspace/ui/lib/utils";
+import { motion } from "motion/react";
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type Heading = {
+  text: string;
+  slug: string;
+  level: number;
+};
+
+type MarkdownTocProps = {
+  headings: Heading[];
+  className?: string;
+};
+
+const SPRING_TRANSITION = {
+  type: "spring" as const,
+  stiffness: 350,
+  damping: 30,
+  mass: 0.8,
+};
+
+/**
+ * Section-aware scroll spy.
+ * Each heading "owns" the region from itself to the next heading.
+ * A heading is active when its section overlaps the viewport.
+ */
+function useActiveSections(headings: Heading[]) {
+  const [activeSlugs, setActiveSlugs] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (headings.length === 0) return;
+
+    const slugs = headings.map((h) => h.slug);
+    let rafId = 0;
+
+    function update() {
+      const active = new Set<string>();
+      const vh = window.innerHeight;
+
+      for (let i = 0; i < slugs.length; i++) {
+        const el = document.getElementById(slugs[i]!);
+        if (!el) continue;
+
+        const sectionTop = el.getBoundingClientRect().top;
+
+        let sectionBottom: number;
+        if (i + 1 < slugs.length) {
+          const nextEl = document.getElementById(slugs[i + 1]!);
+          sectionBottom = nextEl
+            ? nextEl.getBoundingClientRect().top
+            : sectionTop + vh;
+        } else {
+          sectionBottom = Math.max(
+            document.documentElement.scrollHeight -
+              window.scrollY -
+              el.offsetTop +
+              sectionTop,
+            sectionTop + vh,
+          );
+        }
+
+        if (sectionTop < vh && sectionBottom > 0) {
+          active.add(slugs[i]!);
+        }
+      }
+
+      setActiveSlugs(active);
+    }
+
+    function onScroll() {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(update);
+    }
+
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(rafId);
+    };
+  }, [headings]);
+
+  return activeSlugs;
+}
+
+/**
+ * Table of contents for markdown-rendered content.
+ * Expects headings extracted from the markdown string and
+ * matching IDs on the rendered heading elements.
+ */
+export function MarkdownToc({ headings, className }: MarkdownTocProps) {
+  const activeSlugs = useActiveSections(headings);
+  const itemRefs = useRef<Map<string, HTMLLIElement>>(new Map());
+
+  const [indicator, setIndicator] = useState({ top: 0, height: 0 });
+
+  const setItemRef = useCallback(
+    (slug: string) => (el: HTMLLIElement | null) => {
+      if (el) {
+        itemRefs.current.set(slug, el);
+      } else {
+        itemRefs.current.delete(slug);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (activeSlugs.size === 0) {
+      setIndicator({ top: 0, height: 0 });
+      return;
+    }
+
+    let minTop = Infinity;
+    let maxBottom = -Infinity;
+
+    for (const slug of activeSlugs) {
+      const el = itemRefs.current.get(slug);
+      if (!el) continue;
+      minTop = Math.min(minTop, el.offsetTop);
+      maxBottom = Math.max(maxBottom, el.offsetTop + el.offsetHeight);
+    }
+
+    if (minTop === Infinity) return;
+    setIndicator({ top: minTop, height: maxBottom - minTop });
+  }, [activeSlugs]);
+
+  if (headings.length === 0) return null;
+
+  return (
+    <nav
+      aria-label="Table of contents"
+      className={cn("flex flex-col gap-4", className)}
+    >
+      <p className="text-sm font-medium text-foreground">In this Pitch</p>
+
+      <div className="relative border-l border-border">
+        <motion.div
+          animate={{
+            top: indicator.top,
+            height: indicator.height,
+            opacity: activeSlugs.size > 0 ? 1 : 0,
+          }}
+          className="absolute -left-px w-[2px] bg-pink-500"
+          initial={false}
+          transition={SPRING_TRANSITION}
+        />
+
+        <ul className="flex flex-col">
+          {headings.map((heading) => {
+            const isActive = activeSlugs.has(heading.slug);
+            return (
+              <li key={heading.slug} ref={setItemRef(heading.slug)}>
+                <Link
+                  className={cn(
+                    "block px-6 py-1.5 text-sm leading-snug transition-colors duration-200",
+                    isActive
+                      ? "font-medium text-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                  href={`#${heading.slug}`}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    const target = document.getElementById(heading.slug);
+                    if (target) {
+                      target.scrollIntoView({ behavior: "smooth" });
+                      window.history.pushState(null, "", `#${heading.slug}`);
+                    }
+                  }}
+                >
+                  {heading.text}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/src/components/startup/startup-detail.tsx
+++ b/apps/web/src/components/startup/startup-detail.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 
 import { SanityImage } from "@/components/elements/sanity-image";
 import { AiAnalysisPanel } from "./ai-analysis-panel";
+import { MarkdownToc } from "./markdown-toc";
 import { ShareButton } from "./share-button";
 import { UpvoteButton } from "./upvote-button";
 
@@ -13,6 +14,49 @@ const md = markdownit({
   linkify: true,
   typographer: true,
 });
+
+// Inject IDs into heading tags so the ToC can link to them.
+const defaultHeadingOpen =
+  md.renderer.rules.heading_open ||
+  ((tokens, idx, options, _env, self) =>
+    self.renderToken(tokens, idx, options));
+
+md.renderer.rules.heading_open = (tokens, idx, options, env, self) => {
+  const token = tokens[idx];
+  if (!token) return defaultHeadingOpen(tokens, idx, options, env, self);
+  const next = tokens[idx + 1];
+  const text =
+    next?.children?.map((t) => t.content).join("") || next?.content || "";
+  const slug = text
+    .toLowerCase()
+    .replace(/[^\w]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  token.attrSet("id", slug);
+  return defaultHeadingOpen(tokens, idx, options, env, self);
+};
+
+type MarkdownHeading = { text: string; slug: string; level: number };
+
+/** Extract h2/h3 headings from a raw markdown string. */
+function extractMarkdownHeadings(markdown: string): MarkdownHeading[] {
+  const regex = /^(#{2,3})\s+(.+)$/gm;
+  const headings: MarkdownHeading[] = [];
+  let match = regex.exec(markdown);
+  while (match) {
+    const level = match[1];
+    const rawText = match[2];
+    if (level && rawText) {
+      const text = rawText.trim();
+      const slug = text
+        .toLowerCase()
+        .replace(/[^\w]+/g, "-")
+        .replace(/(^-|-$)/g, "");
+      headings.push({ text, slug, level: level.length });
+    }
+    match = regex.exec(markdown);
+  }
+  return headings;
+}
 
 type Startup = NonNullable<QueryStartupByIdResult>;
 type Author = NonNullable<Startup["author"]>;
@@ -25,7 +69,7 @@ type Props = {
 // ── Prose class string (extracted to keep JSX readable) ──
 
 const PROSE_CLASSES =
-  "prose prose-lg dark:prose-invert max-w-none prose-headings:font-bold prose-headings:tracking-tight prose-h2:mt-14 prose-h2:mb-5 prose-h2:text-2xl prose-h3:mt-10 prose-h3:mb-4 prose-p:leading-relaxed prose-p:text-neutral-600 dark:prose-p:text-white/65 prose-a:text-pink-500 prose-a:underline prose-a:decoration-pink-500/30 prose-a:underline-offset-2 hover:prose-a:decoration-pink-500 prose-strong:text-neutral-800 dark:prose-strong:text-white prose-ul:text-neutral-600 dark:prose-ul:text-white/65 prose-ol:text-neutral-600 dark:prose-ol:text-white/65 prose-li:marker:text-pink-400/50 prose-code:rounded-md prose-code:bg-neutral-100 dark:prose-code:bg-white/8 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:text-pink-500 dark:prose-code:text-pink-400 prose-code:before:content-none prose-code:after:content-none prose-pre:rounded-xl prose-pre:border prose-pre:border-neutral-200 dark:prose-pre:border-white/10 prose-pre:bg-neutral-50 dark:prose-pre:bg-neutral-900 prose-blockquote:not-italic prose-blockquote:border-l-2 prose-blockquote:border-pink-500/50 prose-blockquote:pl-5 prose-blockquote:text-neutral-500 dark:prose-blockquote:text-white/50 prose-hr:border-neutral-200 dark:prose-hr:border-white/10 prose-img:rounded-xl";
+  "prose prose-base md:prose-lg dark:prose-invert max-w-none prose-headings:font-bold prose-headings:tracking-tight prose-h2:mt-8 prose-h2:md:mt-14 prose-h2:mb-3 prose-h2:md:mb-5 prose-h2:text-xl prose-h2:sm:text-2xl prose-h3:mt-6 prose-h3:md:mt-10 prose-h3:mb-3 prose-h3:md:mb-4 prose-h3:text-lg prose-h3:sm:text-xl prose-p:leading-relaxed prose-p:text-neutral-600 dark:prose-p:text-white/65 prose-a:text-pink-500 prose-a:underline prose-a:decoration-pink-500/30 prose-a:underline-offset-2 hover:prose-a:decoration-pink-500 prose-strong:text-neutral-800 dark:prose-strong:text-white prose-ul:text-neutral-600 dark:prose-ul:text-white/65 prose-ol:text-neutral-600 dark:prose-ol:text-white/65 prose-li:marker:text-pink-400/50 prose-code:rounded-md prose-code:bg-neutral-100 dark:prose-code:bg-white/8 prose-code:px-1.5 prose-code:py-0.5 prose-code:text-sm prose-code:text-pink-500 dark:prose-code:text-pink-400 prose-code:before:content-none prose-code:after:content-none prose-pre:rounded-xl prose-pre:border prose-pre:border-neutral-200 dark:prose-pre:border-white/10 prose-pre:bg-neutral-50 dark:prose-pre:bg-neutral-900 prose-blockquote:not-italic prose-blockquote:border-l-2 prose-blockquote:border-pink-500/50 prose-blockquote:pl-5 prose-blockquote:text-neutral-500 dark:prose-blockquote:text-white/50 prose-hr:border-neutral-200 dark:prose-hr:border-white/10 prose-img:rounded-xl";
 
 // ── Sub-components ──
 
@@ -74,48 +118,53 @@ function AuthorChip({ author }: { author: Author }) {
   );
 }
 
-/** Sticky sidebar card for the pitch author. */
-function AuthorSidebar({ author }: { author: Author }) {
+/** Author card content (without wrapper). Used inside the sticky sidebar. */
+function AuthorSidebarContent({ author }: { author: Author }) {
   return (
-    <aside className="lg:w-72 lg:shrink-0">
-      <div className="sticky top-28 overflow-hidden rounded-2xl border border-neutral-200/60 dark:border-white/10">
-        {/* Gradient accent bar */}
-        <div className="h-1 bg-gradient-to-r from-pink-500 via-orange-400 to-pink-500" />
+    <div className="overflow-hidden rounded-2xl border border-neutral-200/60 dark:border-white/10">
+      <div className="h-1 bg-gradient-to-r from-pink-500 via-orange-400 to-pink-500" />
+      <div className="bg-gradient-to-b from-neutral-50/80 to-white p-6 dark:from-white/[0.04] dark:to-transparent">
+        <p className="mb-5 text-xs font-semibold uppercase tracking-widest text-neutral-400 dark:text-white/25">
+          Pitched by
+        </p>
 
-        <div className="bg-gradient-to-b from-neutral-50/80 to-white p-6 dark:from-white/[0.04] dark:to-transparent">
-          <p className="mb-5 text-xs font-semibold uppercase tracking-widest text-neutral-400 dark:text-white/25">
-            Pitched by
+        <Link href={`/user/${author._id}`} className="group block">
+          <div className="mb-4 w-fit rounded-full ring-2 ring-neutral-200 transition group-hover:ring-pink-400/50 dark:ring-white/10 dark:group-hover:ring-pink-500/40">
+            <AuthorAvatar author={author} size="lg" />
+          </div>
+
+          <p className="text-base font-semibold text-neutral-900 transition group-hover:text-pink-500 dark:text-white">
+            {author.name}
           </p>
-
-          <Link href={`/user/${author._id}`} className="group block">
-            <div className="mb-4 ring-2 ring-neutral-200 transition group-hover:ring-pink-400/50 dark:ring-white/10 dark:group-hover:ring-pink-500/40 rounded-full w-fit">
-              <AuthorAvatar author={author} size="lg" />
-            </div>
-
-            <p className="text-base font-semibold text-neutral-900 transition group-hover:text-pink-500 dark:text-white">
-              {author.name}
-            </p>
-            {author.username && (
-              <p className="mt-0.5 text-sm text-neutral-400 dark:text-white/35">
-                @{author.username}
-              </p>
-            )}
-          </Link>
-
-          {author.bio && (
-            <p className="mt-3 text-sm leading-relaxed text-neutral-500 dark:text-white/45">
-              {author.bio}
+          {author.username && (
+            <p className="mt-0.5 text-sm text-neutral-400 dark:text-white/35">
+              @{author.username}
             </p>
           )}
+        </Link>
 
-          <Link
-            href={`/user/${author._id}`}
-            className="mt-5 inline-flex text-sm font-medium text-pink-500 transition hover:text-pink-600 dark:text-pink-400 dark:hover:text-pink-300"
-          >
-            View all pitches &rarr;
-          </Link>
-        </div>
+        {author.bio && (
+          <p className="mt-3 text-sm leading-relaxed text-neutral-500 dark:text-white/45">
+            {author.bio}
+          </p>
+        )}
+
+        <Link
+          href={`/user/${author._id}`}
+          className="mt-5 inline-flex text-sm font-medium text-pink-500 transition hover:text-pink-600 dark:text-pink-400 dark:hover:text-pink-300"
+        >
+          View all pitches &rarr;
+        </Link>
       </div>
+    </div>
+  );
+}
+
+/** Full author sidebar with wrapper — used on mobile. */
+function AuthorSidebar({ author }: { author: Author }) {
+  return (
+    <aside className="w-full">
+      <AuthorSidebarContent author={author} />
     </aside>
   );
 }
@@ -177,6 +226,7 @@ export function StartupDetail({ startup, children }: Props) {
   });
 
   const parsedPitch = pitch ? md.render(pitch) : "";
+  const pitchHeadings = pitch ? extractMarkdownHeadings(pitch) : [];
 
   const wordCount = pitch ? pitch.split(/\s+/).length : 0;
   const readingTime = Math.max(1, Math.ceil(wordCount / 200));
@@ -184,9 +234,9 @@ export function StartupDetail({ startup, children }: Props) {
   return (
     <article>
       {/* ── Contained Hero ── */}
-      <section className="container px-6 pt-6 md:px-10">
+      <section className="container px-6 pt-20 md:px-10">
         <div className="relative overflow-hidden rounded-2xl md:rounded-3xl">
-          <div className="relative aspect-video w-full">
+          <div className="relative h-auto max-h-150 w-full">
             <SanityImage
               image={image}
               className="size-full object-cover"
@@ -274,7 +324,21 @@ export function StartupDetail({ startup, children }: Props) {
             {children}
           </div>
 
-          {author && <AuthorSidebar author={author} />}
+          {/* Right sidebar — ToC + Author */}
+          <div className="hidden lg:flex lg:w-72 lg:shrink-0 lg:flex-col lg:gap-8">
+            <div className="sticky top-28 flex flex-col gap-8">
+              {pitchHeadings.length > 0 && (
+                <MarkdownToc headings={pitchHeadings} />
+              )}
+              {author && <AuthorSidebarContent author={author} />}
+            </div>
+          </div>
+          {/* Mobile: author sidebar below content */}
+          {author && (
+            <div className="lg:hidden">
+              <AuthorSidebar author={author} />
+            </div>
+          )}
         </div>
       </section>
     </article>

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -167,6 +167,58 @@ img {
   }
 }
 
+/* ── Glow border ── */
+
+@property --glow-hue {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 0;
+}
+
+@property --glow-bg-x {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 50;
+}
+
+@property --glow-bg-y {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 50;
+}
+
+@keyframes glow-hue-cycle {
+  from {
+    --glow-hue: 0;
+  }
+  to {
+    --glow-hue: 360;
+  }
+}
+
+@keyframes glow-border-orbit {
+  0% {
+    --glow-bg-x: 0;
+    --glow-bg-y: 0;
+  }
+  25% {
+    --glow-bg-x: 100;
+    --glow-bg-y: 0;
+  }
+  50% {
+    --glow-bg-x: 100;
+    --glow-bg-y: 100;
+  }
+  75% {
+    --glow-bg-x: 0;
+    --glow-bg-y: 100;
+  }
+  100% {
+    --glow-bg-x: 0;
+    --glow-bg-y: 0;
+  }
+}
+
 .animate-flame {
   animation: flame-pulse 2s ease-in-out infinite;
   transform-origin: bottom center;


### PR DESCRIPTION
## Summary
- Add `glow-border` shared component + supporting `@property`/keyframes in `globals.css`.
- Add `markdown-toc` for the pitch body.
- Redesign `ai-analysis-panel` and `startup-detail`.

`glow-border` (and its CSS) and `markdown-toc` are consumed only by these startup components — shipped together so animations/render don't break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)