### PR TITLE
perf(web): cut Vercel edge/origin usage

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -11,6 +11,13 @@ const nextConfig: NextConfig = {
   reactCompiler: true,
   experimental: {
     inlineCss: true,
+    optimizePackageImports: [
+      "motion",
+      "lucide-react",
+      "radix-ui",
+      "@radix-ui/react-dropdown-menu",
+      "@radix-ui/react-navigation-menu",
+    ],
     serverActions: {
       bodySizeLimit: "1mb",
     },

--- a/apps/web/src/components/blog-card.tsx
+++ b/apps/web/src/components/blog-card.tsx
@@ -43,7 +43,11 @@ export function BlogCard({ blog }: BlogCardProps) {
 
   return (
     <article className="group relative flex flex-col overflow-hidden rounded-2xl border border-neutral-200/60 bg-white/80 shadow-sm backdrop-blur-sm transition duration-300 hover:border-pink-500/20 hover:shadow-md hover:bg-neutral-50/80 dark:border-white/10 dark:bg-neutral-900/60 dark:shadow-none dark:hover:bg-neutral-800/60 dark:hover:shadow-none">
-      <Link href={slug ?? "#"} className="flex flex-1 flex-col">
+      <Link
+        href={slug ?? "#"}
+        className="flex flex-1 flex-col"
+        prefetch={false}
+      >
         {/* Cover image */}
         <div className="relative aspect-video w-full overflow-hidden">
           {image?.id ? (
@@ -113,7 +117,11 @@ export function FeaturedBlogCard({ blog }: BlogCardProps) {
 
   return (
     <article className="group relative overflow-hidden rounded-2xl border border-neutral-200/60 bg-white/80 shadow-sm backdrop-blur-sm transition duration-300 hover:border-pink-500/20 hover:shadow-md hover:bg-neutral-50/80 dark:border-white/10 dark:bg-neutral-900/60 dark:shadow-none dark:hover:bg-neutral-800/60 dark:hover:shadow-none">
-      <Link href={slug ?? "#"} className="grid grid-cols-1 lg:grid-cols-2">
+      <Link
+        href={slug ?? "#"}
+        className="grid grid-cols-1 lg:grid-cols-2"
+        prefetch={false}
+      >
         {/* Cover image */}
         <div className="relative aspect-video w-full overflow-hidden lg:aspect-auto lg:min-h-72">
           {image?.id ? (

--- a/apps/web/src/components/navbar/use-navbar-data.ts
+++ b/apps/web/src/components/navbar/use-navbar-data.ts
@@ -10,14 +10,21 @@ const fetcher = async (url: string): Promise<NavigationData> => {
   return response.json();
 };
 
-/** SWR hook for live-revalidating navbar + settings data. */
+/**
+ * Navbar + settings data hook.
+ *
+ * Nav links and site settings are server-rendered into `initial` and change
+ * very rarely, so there's no client polling — that would fire an Edge Request +
+ * dynamic function invocation per interval, per open tab, for near-static data.
+ * The data refreshes on the next full navigation/load instead.
+ */
 export function useNavbarData(initial: NavigationData) {
   const { data, error } = useSWR<NavigationData>("/api/navigation", fetcher, {
     fallbackData: initial,
     revalidateOnFocus: false,
     revalidateOnMount: false,
-    revalidateOnReconnect: true,
-    refreshInterval: 30_000,
+    revalidateOnReconnect: false,
+    refreshInterval: 0,
     errorRetryCount: 3,
     errorRetryInterval: 5000,
   });

--- a/apps/web/src/components/sections/feature-cards-with-icon.tsx
+++ b/apps/web/src/components/sections/feature-cards-with-icon.tsx
@@ -8,6 +8,7 @@ import avatar4 from "@/../public/images/avatar-owen-garcia.jpg";
 import { Tag } from "@/components/shared/tag";
 import type { PagebuilderType } from "@/types";
 import { RichText } from "../elements/rich-text";
+import { IncredibleHighlight } from "./incredible-highlight";
 
 type FeatureCardsWithIconProps = PagebuilderType<"featureCardsIcon">;
 
@@ -53,7 +54,13 @@ function AvatarsAnimation() {
           )}
         >
           <div className="relative size-full overflow-hidden rounded-full">
-            <Image src={src} alt={alt} fill className="object-cover" />
+            <Image
+              src={src}
+              alt={alt}
+              fill
+              sizes="80px"
+              className="object-cover"
+            />
           </div>
         </div>
       ))}
@@ -63,6 +70,7 @@ function AvatarsAnimation() {
             src={avatar4}
             alt="Avatar 4"
             fill
+            sizes="80px"
             className="object-cover opacity-0 transition-all duration-500 group-hover:opacity-100"
           />
           <div className="flex size-full items-center justify-center gap-1">
@@ -82,19 +90,7 @@ function AvatarsAnimation() {
 function TextHighlightAnimation() {
   return (
     <p className="text-center text-4xl font-extrabold text-neutral-200 dark:text-white/20 transition duration-500 group-hover:text-neutral-200 dark:group-hover:text-white/10">
-      We&apos;ve achieved{" "}
-      <span className="relative bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
-        <span>incredible</span>
-        <video
-          src="/gif-incredible.mp4"
-          autoPlay
-          loop
-          muted
-          playsInline
-          className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 rounded-2xl opacity-0 shadow-xl transition duration-500 group-hover:opacity-100"
-        />
-      </span>{" "}
-      <br />
+      We&apos;ve achieved <IncredibleHighlight /> <br />
       milestones this year.
     </p>
   );

--- a/apps/web/src/components/sections/incredible-highlight.tsx
+++ b/apps/web/src/components/sections/incredible-highlight.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useRef } from "react";
+
+/**
+ * The "incredible" highlight word with a decorative hover-reveal video.
+ *
+ * The video is a purely decorative hover effect, so it uses `preload="none"`
+ * and only starts loading/playing on hover intent — instead of `autoPlay`,
+ * which forced every visitor to download the full ~328KB clip on page load
+ * even though it stays hidden until hover.
+ */
+export function IncredibleHighlight() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: decorative hover-only video; nothing essential is lost without the pointer interaction
+    <span
+      className="group/incredible relative bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent"
+      onMouseEnter={() => {
+        videoRef.current?.play().catch(() => {
+          // Ignore autoplay-policy / interrupted-play rejections.
+        });
+      }}
+    >
+      <span>incredible</span>
+      <video
+        aria-hidden="true"
+        className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 rounded-2xl opacity-0 shadow-xl transition duration-500 group-hover/incredible:opacity-100"
+        loop
+        muted
+        playsInline
+        preload="none"
+        ref={videoRef}
+        src="/gif-incredible.mp4"
+        tabIndex={-1}
+      />
+    </span>
+  );
+}

--- a/apps/web/src/components/startup/startup-card.tsx
+++ b/apps/web/src/components/startup/startup-card.tsx
@@ -45,7 +45,11 @@ export function StartupCard({ post }: { post: StartupCardItem }) {
 
   return (
     <article className="group relative h-full overflow-hidden rounded-2xl bg-white ring-1 ring-neutral-200/80 transition duration-300 hover:ring-pink-300/60 hover:shadow-lg hover:shadow-pink-500/5 dark:bg-neutral-900 dark:ring-white/10 dark:hover:ring-pink-500/30 dark:hover:shadow-pink-500/10">
-      <Link href={`/startup/${_id}`} className="flex h-full flex-col">
+      <Link
+        href={`/startup/${_id}`}
+        className="flex h-full flex-col"
+        prefetch={false}
+      >
         {/* Cover image */}
         <div className="relative aspect-video w-full overflow-hidden">
           <SanityImage

--- a/apps/web/src/components/startup/views-badge.tsx
+++ b/apps/web/src/components/startup/views-badge.tsx
@@ -1,19 +1,15 @@
 import { Logger } from "@workspace/logger";
-import { client } from "@workspace/sanity/client";
-import { queryStartupViews } from "@workspace/sanity/query";
 import { writeClient } from "@workspace/sanity/write-client";
 import { after } from "next/server";
 
 const logger = new Logger("views-badge");
 
 /**
- * Server component that increments view count on render.
+ * Server component that increments the view count on render.
  * Uses after() to atomically increment views without blocking render.
  * Renders nothing — the count is displayed in the floating stats bar.
  */
-export async function ViewsBadge({ id }: { id: string }) {
-  await client.withConfig({ useCdn: false }).fetch(queryStartupViews, { id });
-
+export function ViewsBadge({ id }: { id: string }) {
   after(async () => {
     try {
       await writeClient.patch(id).inc({ views: 1 }).commit();


### PR DESCRIPTION
Reduces Vercel Edge Requests, Function Invocations, and Fast Origin/Data Transfer with low-risk, no-feature-loss changes. Findings from a deep audit of `apps/web`.

## Changes

**Defer the decorative "incredible" video** (`sections/incredible-highlight.tsx` + `feature-cards-with-icon.tsx`)
Was `autoPlay` → downloaded the full ~328KB clip on every page load even though it's `opacity-0` until hover. Now `preload="none"` + play-on-hover. Biggest single Fast-Data-Transfer item on the site.

**`prefetch={false}` on card links** (`startup-card.tsx`, `blog-card.tsx`)
Listings map all items client-side, so every card was viewport-prefetching its dynamic route on scroll → Edge Request + RSC payload each. Disabled.

**Remove `ViewsBadge` dead fetch** (`views-badge.tsx`)
A non-CDN (origin-hitting) Sanity fetch ran on every startup view and its result was discarded. Deleted; the `after()` view increment is unchanged.

**Disable navbar 30s polling** (`navbar/use-navbar-data.ts`)
`refreshInterval: 30_000` re-fetched `/api/navigation` (a dynamic route) every 30s per open tab, for near-static nav/settings — a triple-hit (Edge Requests + Function Invocations + Fast Origin Transfer). Data is already server-rendered into the SWR `fallbackData`; nav now refreshes on full navigation instead.

**Bundle** — `experimental.optimizePackageImports` for `motion`/`lucide-react`/`radix-ui`, and `sizes="80px"` on the fixed-size feature-card avatars.

## Verification
- `tsc --noEmit` clean, `biome check` clean.
- (Full `next build` needs Sanity env/credentials — its `redirects()` fetches at build time — so not run locally; CI/Vercel preview build covers it.)

## Not included (deliberately, higher risk)
- `sanityFetch` → ISR migration (needs preview gating + `revalidateTag` webhook)
- Un-clienting `pagebuilder` + server-rendering `TopPitches`
- Capping the unbounded startup-list queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)